### PR TITLE
Added callback support for Shiny

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,4 +23,4 @@ Imports:
 Suggests:
     testthat
 Enhances:
-    shiny (>= 0.10.2.1)
+    shiny (>= 0.12)

--- a/R/fig_layer.R
+++ b/R/fig_layer.R
@@ -43,7 +43,16 @@ add_layer <- function(fig, spec, dat, lname, lgroup, callback = NULL) {
   names(glyph_attrs) <- names(spec)
   if(!is.null(glyph_attrs$size))
     glyph_attrs$size$units <- "screen"
-
+  
+  if(!is.null(glyph_attrs$start_angle))
+    glyph_attrs$start_angle$units <- "rad"
+  
+  if(!is.null(glyph_attrs$end_angle))
+    glyph_attrs$end_angle$units <- "rad"
+  
+  if(!is.null(glyph_attrs$angle))
+    glyph_attrs$angle$units <- "rad"
+  
   if(!is.null(glyph_attrs$line_dash))
     glyph_attrs$line_dash <- glyph_attrs$line_dash$value
 

--- a/R/fig_layer.R
+++ b/R/fig_layer.R
@@ -13,7 +13,7 @@
 ## these are all internal functions called from make_glyph
 ## which is called from the various layer functions
 
-add_layer <- function(fig, spec, dat, lname, lgroup) {
+add_layer <- function(fig, spec, dat, lname, lgroup, callback = NULL) {
   glyph <- spec$glyph
   glyph <- underscore2camel(glyph)
   spec$glyph <- NULL
@@ -87,6 +87,11 @@ add_layer <- function(fig, spec, dat, lname, lgroup) {
   glr_id <- gen_id(fig, c("glyph_renderer", lgroup, lname))
   glyph_rend <- glyph_renderer_model(glr_id, dat_mod$ref, glyph_obj$ref, ns_glyph_obj$ref)
 
+  u_id <- gen_id(fig, c(glr_id, "select_callback"))
+  act <- callback_model(u_id, callback, "select_callback")
+  dat_mod$model$attributes$callback <- act$ref
+  fig$x$spec$model[[u_id]] <- act$model
+  
   fig$x$spec$model$plot$attributes$renderers[[glr_id]] <- glyph_rend$ref
 
   fig$x$spec$model[[d_id]] <- dat_mod$model

--- a/R/fig_url.R
+++ b/R/fig_url.R
@@ -18,6 +18,30 @@ add_tap_url <- function(fig, url, renderer_ref) {
   fig
 }
 
+add_tap_callback <- function(fig, callback, renderer_ref) {
+  
+  u_id <- gen_id(fig, c(renderer_ref$id, "callback"))
+  act <- callback_model(u_id, callback)
+  
+  id <- gen_id(fig, c(renderer_ref$id, "TapTool"))
+  tap <- tap_model(id, fig$x$spec$ref, renderer_ref, act$ref)
+  
+  fig$x$spec$model$plot$attributes$tools[[id]] <- tap$ref
+  fig$x$spec$model[[id]] <- tap$model
+  
+  fig$x$spec$model[[u_id]] <- act$model
+  
+  fig
+}
+
+callback_model <- function(id, callback) {
+  res <- base_model_object("Callback", id)
+  res$model$attributes$args <- list()
+  res$model$attributes$code <- callback
+  
+  res
+}
+
 tap_model <- function(id, plot_ref, renderer_ref, action_ref) {
   res <- base_model_object("TapTool", id)
   res$model$attributes$plot <- plot_ref

--- a/R/fig_url.R
+++ b/R/fig_url.R
@@ -36,8 +36,8 @@ add_tap_callback <- function(fig, callback, renderer_ref) {
 
 callback_model <- function(id, callback) {
   res <- base_model_object("Callback", id)
-  res$model$attributes$args <- list()
-  res$model$attributes$code <- callback
+  res$model$attributes$args <- callback
+  res$model$attributes$code <- NULL
   
   res
 }

--- a/R/fig_url.R
+++ b/R/fig_url.R
@@ -18,10 +18,10 @@ add_tap_url <- function(fig, url, renderer_ref) {
   fig
 }
 
-add_tap_callback <- function(fig, callback, renderer_ref) {
+add_tap_callback <- function(fig, callback, renderer_ref, code) {
   
   u_id <- gen_id(fig, c(renderer_ref$id, "callback"))
-  act <- callback_model(u_id, callback)
+  act <- callback_model(u_id, callback, code)
   
   id <- gen_id(fig, c(renderer_ref$id, "TapTool"))
   tap <- tap_model(id, fig$x$spec$ref, renderer_ref, act$ref)
@@ -34,10 +34,10 @@ add_tap_callback <- function(fig, callback, renderer_ref) {
   fig
 }
 
-callback_model <- function(id, callback) {
+callback_model <- function(id, callback, code) {
   res <- base_model_object("Callback", id)
   res$model$attributes$args <- callback
-  res$model$attributes$code <- NULL
+  res$model$attributes$code <- code
   
   res
 }

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -418,9 +418,9 @@ get_callback <- function(hn, data) {
   } else if(inherits(tmp, "callbackSpec")) {
     return(tmp)
   } else {
-    if(deparse(hn)[1] == "NULL") {
-      data <- data
-    } else if(is.null(data)) {
+    if(deparse(hn)[1] == "NULL")
+      return(NULL)
+    if(is.null(data)) {
       if(!is.data.frame(hn)) {
         message("callback not added - 'callback' must be a data frame or list of variables present in the data frame supplied as the 'data' argument")
         return(NULL)

--- a/R/helpers.R
+++ b/R/helpers.R
@@ -410,6 +410,43 @@ get_hover <- function(hn, data) {
   ), class = "hoverSpec"))
 }
 
+get_callback <- function(hn, data) {
+  tmp <- try(eval(hn), silent = TRUE)
+  if(is.data.frame(tmp)) {
+    data <- tmp
+    hn <- names(data)
+  } else if(inherits(tmp, "callbackSpec")) {
+    return(tmp)
+  } else {
+    if(deparse(hn)[1] == "NULL") {
+      data <- data
+    } else if(is.null(data)) {
+      if(!is.data.frame(hn)) {
+        message("callback not added - 'callback' must be a data frame or list of variables present in the data frame supplied as the 'data' argument")
+        return(NULL)
+      } else {
+        data <- hn
+        hn <- names(data)
+      }
+    } else {
+      hn <- deparse(hn)[1]
+      hn <- gsub("c\\(|list\\(|\\)| +", "", hn)
+      hn <- strsplit(hn, ",")[[1]]
+      if(all(! hn %in% names(data))) {
+        message("There were no columns: ", paste(hn, collapse = ", "), " in the data for the callback tool - callback not added")
+        return(NULL)
+      }
+      data <- data[hn]
+    }
+  }
+  
+  for(ii in seq_len(ncol(data)))
+    data[[ii]] <- format(data[[ii]])
+  
+  return(structure(list(
+    data = data
+  ), class = "callbackSpec"))
+}
 
 # get the "url" argument and turn it into data and "dict"
 # must be a vector or a string referencing variables in data

--- a/R/layer_points.R
+++ b/R/layer_points.R
@@ -26,7 +26,7 @@
 #' @export
 ly_points <- function(fig, x, y = NULL, data = NULL,
   glyph = 21, color = NULL, alpha = 1, size = 10,
-  hover = NULL, url = NULL, legend = NULL,
+  hover = NULL, url = NULL, callback = NULL, legend = NULL,
   lname = NULL, lgroup = NULL, ...) {
 
   validate_fig(fig, "ly_points")
@@ -49,7 +49,8 @@ ly_points <- function(fig, x, y = NULL, data = NULL,
 
   hover <- get_hover(substitute(hover), data)
   url <- get_url(url, data)
-
+  callback <- get_callback(substitute(callback), data)
+  
   xy_names <- get_xy_names(x, y, xname, yname, args)
   ## translate different x, y types to vectors
   xy <- get_xy_data(x, y)
@@ -110,6 +111,6 @@ ly_points <- function(fig, x, y = NULL, data = NULL,
   make_glyph(fig, args$glyph, lname = lname, lgroup = lgroup,
     data = xy, data_sig = ifelse(is.null(data), NA, digest(data)),
     args = args, axis_type_range = axis_type_range,
-    hover = hover, url = url, legend = legend,
+    hover = hover, url = url, callback = callback, legend = legend,
     xname = xy_names$x, yname = xy_names$y)
 }

--- a/R/layer_points.R
+++ b/R/layer_points.R
@@ -26,7 +26,7 @@
 #' @export
 ly_points <- function(fig, x, y = NULL, data = NULL,
   glyph = 21, color = NULL, alpha = 1, size = 10,
-  hover = NULL, url = NULL, callback = NULL, legend = NULL,
+  hover = NULL, url = NULL, callback = data, legend = NULL,
   lname = NULL, lgroup = NULL, ...) {
 
   validate_fig(fig, "ly_points")
@@ -49,7 +49,8 @@ ly_points <- function(fig, x, y = NULL, data = NULL,
 
   hover <- get_hover(substitute(hover), data)
   url <- get_url(url, data)
-  callback <- get_callback(substitute(callback), data)
+  if (!is.null(data))
+    callback <- get_callback(substitute(callback), data)
   
   xy_names <- get_xy_names(x, y, xname, yname, args)
   ## translate different x, y types to vectors

--- a/R/make_glyph.R
+++ b/R/make_glyph.R
@@ -159,7 +159,7 @@ make_glyph <- function(fig, type, lname, lgroup, data, args, axis_type_range,
       id = glr_id
     )
     
-    fig <- fig %>% add_tap_callback(callback, renderer_ref)
+    fig <- fig %>% add_tap_callback(callback, renderer_ref, "callback")
   }
 
   args$glyph <- type
@@ -184,7 +184,7 @@ make_glyph <- function(fig, type, lname, lgroup, data, args, axis_type_range,
       data$y1 <- to_epoch(data$y1)
   }
 
-  fig <- fig %>% add_layer(args, data, lname, lgroup)
+  fig <- fig %>% add_layer(args, data, lname, lgroup, callback)
 
   ## add x and y range for this glyph
   fig$x$spec$glyph_x_ranges[[lgn]] <- axis_type_range$x_range

--- a/R/make_glyph.R
+++ b/R/make_glyph.R
@@ -4,7 +4,8 @@
 # which will ensure that attributes are mapped to glyphs within the layer
 
 make_glyph <- function(fig, type, lname, lgroup, data, args, axis_type_range,
-  hover = NULL, url = NULL, legend = NULL, xname = NULL, yname = NULL, data_sig = NA) {
+  hover = NULL, url = NULL, callback = NULL, legend = NULL, xname = NULL, 
+  yname = NULL, data_sig = NA) {
 
   if(is.null(args))
     args <- list()
@@ -152,6 +153,13 @@ make_glyph <- function(fig, type, lname, lgroup, data, args, axis_type_range,
 
     fig <- fig %>% add_tap_url(url$url, renderer_ref)
     data <- c(data, url$data)
+  }  else {
+    renderer_ref <- list(
+      type = "GlyphRenderer",
+      id = glr_id
+    )
+    
+    fig <- fig %>% add_tap_callback(callback, renderer_ref)
   }
 
   args$glyph <- type

--- a/inst/examples/shiny_callback.R
+++ b/inst/examples/shiny_callback.R
@@ -1,0 +1,39 @@
+library(shiny)
+library(rbokeh)
+
+df = data.frame(group = rep(c("red", "blue"), 5), x = rnorm(10), y = rnorm(10))
+
+ui = shinyUI(fixedPage(
+  fixedRow(
+    rbokehOutput("rbka")
+  ),
+  fixedRow(
+    textOutput("rbka_callback")
+  ),
+  fixedRow(
+    rbokehOutput("rbka_sub")
+  )
+))
+
+server = function(input, output) {
+  output$rbka <- renderRbokeh({
+    figure(xlab = "x", ylab = "y", xlim = c(-2, 2), ylim = c(-2, 2)) %>%
+      ly_points(x, y, data = df, color = group) #, url = "http://www.google.com?q=@group")
+  })
+  
+  output$rbka_callback <- renderPrint({
+    if (!is.null(input$rbka_callback))
+      input$rbka_callback
+  })
+  
+  output$rbka_sub <- renderRbokeh({
+    if (!is.null(input$rbka_callback)) {
+      print(input$rbka_callback)
+      figure(xlab = "x", ylab = "y", xlim = c(-2, 2), ylim = c(-2, 2)) %>%
+        ly_points(x, y, data = df[df$group == input$rbka_callback$fill_color, ],
+                  color = group)
+    }
+  })
+}
+
+shinyApp(ui = ui, server = server)

--- a/inst/examples/shiny_callback.R
+++ b/inst/examples/shiny_callback.R
@@ -1,8 +1,6 @@
 library(shiny)
 library(rbokeh)
 
-df = data.frame(group = rep(c("a", "b"), 5), x = rnorm(10), y = rnorm(10))
-
 ui = shinyUI(fixedPage(
   fixedRow(
     rbokehOutput("rbka")
@@ -16,9 +14,14 @@ ui = shinyUI(fixedPage(
 ))
 
 server = function(input, output) {
+  df_sub = data.frame()
+  
   output$rbka <- renderRbokeh({
-    figure(xlab = "x", ylab = "y", xlim = c(-2, 2), ylim = c(-2, 2)) %>%
-      ly_points(x, y, data = df, color = group) #, callback = list(x, y, group)) 
+    df = data.frame(group = rep(c("a", "b"), 5), x = rnorm(10), y = rnorm(10))
+    
+    figure(xlab = "x", ylab = "y", xlim = c(-2, 2), ylim = c(-2, 2), 
+           tools = c("lasso_select")) %>%
+      ly_points(x, y, data = df) #, color = group) #, callback = list(x, y, group)) 
     #, url = "http://www.google.com?q=@group")
   })
   
@@ -28,11 +31,26 @@ server = function(input, output) {
   })
   
   output$rbka_sub <- renderRbokeh({
-    if (!is.null(input$rbka_callback)) {
-      print(input$rbka_callback)
-      figure(xlab = "x", ylab = "y", xlim = c(-2, 2), ylim = c(-2, 2)) %>%
-        ly_points(x, y, data = df[df$group == input$rbka_callback$group, ],
-                  color = group)
+    if (!is.null(input$rbka_callback) && length(input$rbka_callback) > 0) {
+      df2 = data.frame(do.call(rbind, lapply(input$rbka_callback, unlist)), stringsAsFactors = FALSE)
+      df2$x = as.numeric(df2$x)
+      df2$y = as.numeric(df2$y)
+        
+      print(df2)
+      
+      figure(xlab = "x", ylab = "y", xlim = c(-2, 2), ylim = c(-2, 2), title = "callback") %>%
+        ly_points(x, y, data = df2)
+    } else if (!is.null(input$rbka_select_callback) && length(input$rbka_select_callback) > 0) {
+      df2 = data.frame(do.call(rbind, lapply(input$rbka_select_callback, unlist)), stringsAsFactors = FALSE)
+      df2$x = as.numeric(df2$x)
+      df2$y = as.numeric(df2$y)
+      
+      print(df2)
+      
+      figure(xlab = "x", ylab = "y", xlim = c(-2, 2), ylim = c(-2, 2), title = "select_callback") %>%
+        ly_points(x, y, data = df2)
+    } else {
+      NULL
     }
   })
 }

--- a/inst/examples/shiny_callback.R
+++ b/inst/examples/shiny_callback.R
@@ -1,7 +1,7 @@
 library(shiny)
 library(rbokeh)
 
-df = data.frame(group = rep(c("red", "blue"), 5), x = rnorm(10), y = rnorm(10))
+df = data.frame(group = rep(c("a", "b"), 5), x = rnorm(10), y = rnorm(10))
 
 ui = shinyUI(fixedPage(
   fixedRow(
@@ -18,7 +18,8 @@ ui = shinyUI(fixedPage(
 server = function(input, output) {
   output$rbka <- renderRbokeh({
     figure(xlab = "x", ylab = "y", xlim = c(-2, 2), ylim = c(-2, 2)) %>%
-      ly_points(x, y, data = df, color = group) #, url = "http://www.google.com?q=@group")
+      ly_points(x, y, data = df, color = group) #, callback = list(x, y, group)) 
+    #, url = "http://www.google.com?q=@group")
   })
   
   output$rbka_callback <- renderPrint({
@@ -30,7 +31,7 @@ server = function(input, output) {
     if (!is.null(input$rbka_callback)) {
       print(input$rbka_callback)
       figure(xlab = "x", ylab = "y", xlim = c(-2, 2), ylim = c(-2, 2)) %>%
-        ly_points(x, y, data = df[df$group == input$rbka_callback$fill_color, ],
+        ly_points(x, y, data = df[df$group == input$rbka_callback$group, ],
                   color = group)
     }
   })

--- a/inst/htmlwidgets/rbokeh.js
+++ b/inst/htmlwidgets/rbokeh.js
@@ -100,7 +100,7 @@ HTMLWidgets.widget({
 
       // install the callback
       if (!prevActionCallback)
-        x.all_models[ind].attributes.code = "rslt = getBokehSelected(cb_obj);" +
+        x.all_models[ind].attributes.code = "rslt = getBokehSelected(cb_obj, data);" +
           "var input_id = '" + id + "_callback';" +
           "Bokeh.logger.info('Sending data to shiny: ' + input_id);" +
           "Shiny.onInputChange(input_id, rslt);";
@@ -111,9 +111,9 @@ HTMLWidgets.widget({
 
 });
 
-getBokehSelected = function(cb_obj) {
+getBokehSelected = function(cb_obj, data) {
   var inds = cb_obj.get('selected')['1d'].indices;
-  var data = cb_obj.get('data');
+  //var data = cb_obj.get('data')
 
   var rslt = {};
   for (i = 0; i < inds.length; i++) {

--- a/inst/htmlwidgets/rbokeh.js
+++ b/inst/htmlwidgets/rbokeh.js
@@ -32,6 +32,9 @@ HTMLWidgets.widget({
       }
     }
 
+    if (HTMLWidgets.shinyMode)
+      this.addActionCallbackShinyInput(el.id, x);
+
     Bokeh.logger.info("Realizing plot:")
     Bokeh.logger.info(" - modeltype: " + x.modeltype);
     Bokeh.logger.info(" - modelid:   " + x.modelid);
@@ -81,7 +84,45 @@ HTMLWidgets.widget({
       // TODO: also shrink font sizes, etc., to a certain degree?
       Bokeh.index[instance.modelid].canvas._set_dims([width - w_pad,height - h_pad]);
     }
+  },
+  
+  addActionCallbackShinyInput : function(id, x) {
+    var ind = -1;
+    for(var i = 0; i < x.all_models.length; i += 1) {
+        if(x.all_models[i].type === "Callback") {
+            ind = i;
+        }
+    }
+
+    if (ind > -1) {
+      // check for an existing actionCallback
+      var prevActionCallback = x.all_models[ind].attributes.code;
+
+      // install the callback
+      if (!prevActionCallback)
+        x.all_models[ind].attributes.code = "rslt = getBokehSelected(cb_obj);" +
+          "var input_id = '" + id + "_callback';" +
+          "Bokeh.logger.info('Sending data to shiny: ' + input_id);" +
+          "Shiny.onInputChange(input_id, rslt);";
+    } else {
+      Bokeh.logger.info('No callback model present');
+    }
   }
 
 });
 
+getBokehSelected = function(cb_obj) {
+  var inds = cb_obj.get('selected')['1d'].indices;
+  var data = cb_obj.get('data');
+
+  var rslt = {};
+  for (i = 0; i < inds.length; i++) {
+    for (var key in data) {
+      if (data.hasOwnProperty(key)) {
+        rslt[key] = data[key][inds[i]];
+      }
+    }
+  }
+
+  return(rslt);
+};

--- a/inst/htmlwidgets/rbokeh.js
+++ b/inst/htmlwidgets/rbokeh.js
@@ -10,7 +10,7 @@ HTMLWidgets.widget({
       elementid: "",
       width: width,
       height: height
-    }
+    };
   },
 
   renderValue: function(el, x, instance) {
@@ -18,7 +18,7 @@ HTMLWidgets.widget({
     //clear el for Shiny/dynamic contexts
     el.innerHTML = "";
 
-    if(x.isJSON == true) {
+    if(x.isJSON === true) {
       x.all_models = JSON.parse(x.all_models);
     }
 
@@ -35,7 +35,7 @@ HTMLWidgets.widget({
     if (HTMLWidgets.shinyMode)
       this.addActionCallbackShinyInput(el.id, x);
 
-    Bokeh.logger.info("Realizing plot:")
+    Bokeh.logger.info("Realizing plot:");
     Bokeh.logger.info(" - modeltype: " + x.modeltype);
     Bokeh.logger.info(" - modelid:   " + x.modelid);
     Bokeh.logger.info(" - elementid: " + x.elementid);
@@ -43,7 +43,7 @@ HTMLWidgets.widget({
     instance.modelid = x.modelid;
     instance.elementid = x.elementid;
 
-    if(x.debug == true) {
+    if(x.debug === true) {
       console.log(x.all_models);
       console.log(JSON.stringify(x.all_models));
     }
@@ -87,23 +87,25 @@ HTMLWidgets.widget({
   },
   
   addActionCallbackShinyInput : function(id, x) {
-    var ind = -1;
+    var ind = [];
     for(var i = 0; i < x.all_models.length; i += 1) {
         if(x.all_models[i].type === "Callback") {
-            ind = i;
+            ind.push(i);
         }
     }
 
-    if (ind > -1) {
-      // check for an existing actionCallback
-      var prevActionCallback = x.all_models[ind].attributes.code;
-
-      // install the callback
-      if (!prevActionCallback)
-        x.all_models[ind].attributes.code = "rslt = getBokehSelected(cb_obj, data);" +
-          "var input_id = '" + id + "_callback';" +
+    if (ind.length > 0) {
+      for(var j = 0; j < ind.length; j += 1) {
+        var code = x.all_models[ind[j]].attributes.code;
+  
+        // install the callback
+        Bokeh.logger.info('Adding callback model using ' + id + '_' + code);
+        x.all_models[ind[j]].attributes.code = "rslt = getBokehSelected(cb_obj, data);" +
+          "var input_id = '" + id + "_" + code + "';" +
           "Bokeh.logger.info('Sending data to shiny: ' + input_id);" +
+          "console.log(rslt);" +
           "Shiny.onInputChange(input_id, rslt);";
+      }
     } else {
       Bokeh.logger.info('No callback model present');
     }
@@ -117,11 +119,14 @@ getBokehSelected = function(cb_obj, data) {
 
   var rslt = {};
   for (i = 0; i < inds.length; i++) {
+    //Bokeh.logger.info('Found callback data: ' + inds[i]);
+    val = {};
     for (var key in data) {
       if (data.hasOwnProperty(key)) {
-        rslt[key] = data[key][inds[i]];
+        val[key] = data[key][inds[i]];
       }
     }
+    rslt[inds[i]] = val;
   }
 
   return(rslt);


### PR DESCRIPTION
Here's a first attempt at using the new bokeh callback functionality in Shiny.  A few items to consider improving:
* The TapTool callback is enabled by default if the `url` param to `make_glyph` is not specified and `shinyMode` is detected in JS.  Would it be better to create a `fig_callback` function that enables the callback and allows specification of additional params?
* A `callback` param was added to `make_glyph` but is not currently used.  Could this be used to allow the user to specify fields to be returned as part of the callback call?  Currently only the data point properties are returned, but the shiny example is a great case where returning additional data (group value instead of fill color) would be useful.
* Any other suggestions/ideas?