### PR TITLE
Added additional axis tick format doc

### DIFF
--- a/man-roxygen/dots-axis.R
+++ b/man-roxygen/dots-axis.R
@@ -1,6 +1,5 @@
-#' @param \ldots additional parameters for fine control over axes (see "Additional parameters" below)
-#' @section Additional parameters:
-#' \subsection{Axis}{
+#' @param \ldots additional parameters for fine control over axes (see additional parameters below)
+#' @section Axis parameters:
 #' \tabular{ll}{
 #' \code{axis_label_standoff} \tab (integer) The distance in pixels that the axis labels should be offset from the tick labels. \cr
 #' \code{axis_label_text_align} \tab ('left', 'right', 'center') The text align of the axis label. \cr
@@ -44,8 +43,8 @@
 #' \code{minor_tick_line_join} \tab ('miter', 'round', 'bevel') The line join of the minor ticks. \cr
 #' \code{minor_tick_line_width} \tab (integer) The line width of the minor ticks. \cr
 #' \code{minor_tick_out} \tab (integer) The distance in pixels that major ticks should extend out of the main plot area. \cr
-#'  }}
-#' \subsection{Basic Tick Format}{
+#'  }
+#' @section Basic tick format parameters:
 #' \tabular{ll}{
 #' \code{power_limit_high} \tab (int) Limit the use of scientific notation to when log(x) >= value. \cr
 #' \code{power_limit_low} \tab (int) Limit the use of scientific notation to when log(x) <= value. \cr
@@ -53,19 +52,19 @@
 #'  determined if not specified. \cr
 #' \code{use_scientific} \tab (logical) Whether to ever display scientific notation. If True, then when to use scientific
 #'  notation is controlled by \code{power_limit_low} and \code{power_limit_high}. \cr
-#'  }}
-#' \subsection{Datetime Tick Format}{
+#'  }
+#' @section Datetime tick format parameters:
 #' \tabular{ll}{
 #' \code{formats} \tab (list) Display tick values from a continuous range as formatted datetimes.
 #'  See \href{http://bokeh.pydata.org/en/latest/docs/reference/models.html\#bokeh.models.formatters.DatetimeTickFormatter}{DatetimeTickFormatter}. \cr
-#'  }}
-#' \subsection{Numeral Tick Format}{
+#'  }
+#' @section Numeral tick format parameters:
 #' \tabular{ll}{
 #' \code{format} \tab (string) Tick formatter based on a human-readable format string.
 #'  See \href{http://bokeh.pydata.org/en/latest/docs/reference/models.html\#bokeh.models.formatters.NumeralTickFormatter}{NumeralTickFormatter}. \cr
-#'  }}
-#' \subsection{Printf Tick Format}{
+#'  }
+#' @section Printf tick format parameters:
 #' \tabular{ll}{
 #' \code{format} \tab (string) Tick formatter based on a printf-style format string.
 #'  See \href{http://bokeh.pydata.org/en/latest/docs/reference/models.html\#bokeh.models.formatters.PrintfTickFormatter}{PrintfTickFormatter}. \cr
-#'  }}
+#'  }

--- a/man/x_axis.Rd
+++ b/man/x_axis.Rd
@@ -29,14 +29,13 @@ x_axis(fig, label, position = "below", log = FALSE, grid = TRUE,
 or \href{http://bokeh.pydata.org/en/latest/docs/reference/models.html\#bokeh.models.formatters.PrintfTickFormatter}{"printf"});
 ignored if \code{log} is TRUE}
 
-\item{\ldots}{additional parameters for fine control over axes (see "Additional parameters" below)}
+\item{\ldots}{additional parameters for fine control over axes (see additional parameters below)}
 }
 \description{
 Add x axis to a Bokeh figure
 }
-\section{Additional parameters}{
+\section{Axis parameters}{
 
-\subsection{Axis}{
 \tabular{ll}{
 \code{axis_label_standoff} \tab (integer) The distance in pixels that the axis labels should be offset from the tick labels. \cr
 \code{axis_label_text_align} \tab ('left', 'right', 'center') The text align of the axis label. \cr
@@ -80,8 +79,11 @@ Add x axis to a Bokeh figure
 \code{minor_tick_line_join} \tab ('miter', 'round', 'bevel') The line join of the minor ticks. \cr
 \code{minor_tick_line_width} \tab (integer) The line width of the minor ticks. \cr
 \code{minor_tick_out} \tab (integer) The distance in pixels that major ticks should extend out of the main plot area. \cr
- }}
-\subsection{Basic Tick Format}{
+ }
+}
+
+\section{Basic tick format parameters}{
+
 \tabular{ll}{
 \code{power_limit_high} \tab (int) Limit the use of scientific notation to when log(x) >= value. \cr
 \code{power_limit_low} \tab (int) Limit the use of scientific notation to when log(x) <= value. \cr
@@ -89,22 +91,31 @@ Add x axis to a Bokeh figure
  determined if not specified. \cr
 \code{use_scientific} \tab (logical) Whether to ever display scientific notation. If True, then when to use scientific
  notation is controlled by \code{power_limit_low} and \code{power_limit_high}. \cr
- }}
-\subsection{Datetime Tick Format}{
+ }
+}
+
+\section{Datetime tick format parameters}{
+
 \tabular{ll}{
 \code{formats} \tab (list) Display tick values from a continuous range as formatted datetimes.
  See \href{http://bokeh.pydata.org/en/latest/docs/reference/models.html\#bokeh.models.formatters.DatetimeTickFormatter}{DatetimeTickFormatter}. \cr
- }}
-\subsection{Numeral Tick Format}{
+ }
+}
+
+\section{Numeral tick format parameters}{
+
 \tabular{ll}{
 \code{format} \tab (string) Tick formatter based on a human-readable format string.
  See \href{http://bokeh.pydata.org/en/latest/docs/reference/models.html\#bokeh.models.formatters.NumeralTickFormatter}{NumeralTickFormatter}. \cr
- }}
-\subsection{Printf Tick Format}{
+ }
+}
+
+\section{Printf tick format parameters}{
+
 \tabular{ll}{
 \code{format} \tab (string) Tick formatter based on a printf-style format string.
  See \href{http://bokeh.pydata.org/en/latest/docs/reference/models.html\#bokeh.models.formatters.PrintfTickFormatter}{PrintfTickFormatter}. \cr
- }}
+ }
 }
 \examples{
 \donttest{

--- a/man/y_axis.Rd
+++ b/man/y_axis.Rd
@@ -29,14 +29,13 @@ y_axis(fig, label, position = "left", log = FALSE, grid = TRUE,
 or \href{http://bokeh.pydata.org/en/latest/docs/reference/models.html\#bokeh.models.formatters.PrintfTickFormatter}{"printf"});
 ignored if \code{log} is TRUE}
 
-\item{\ldots}{additional parameters for fine control over axes (see "Additional parameters" below)}
+\item{\ldots}{additional parameters for fine control over axes (see additional parameters below)}
 }
 \description{
 Add y axis to a Bokeh figure
 }
-\section{Additional parameters}{
+\section{Axis parameters}{
 
-\subsection{Axis}{
 \tabular{ll}{
 \code{axis_label_standoff} \tab (integer) The distance in pixels that the axis labels should be offset from the tick labels. \cr
 \code{axis_label_text_align} \tab ('left', 'right', 'center') The text align of the axis label. \cr
@@ -80,8 +79,11 @@ Add y axis to a Bokeh figure
 \code{minor_tick_line_join} \tab ('miter', 'round', 'bevel') The line join of the minor ticks. \cr
 \code{minor_tick_line_width} \tab (integer) The line width of the minor ticks. \cr
 \code{minor_tick_out} \tab (integer) The distance in pixels that major ticks should extend out of the main plot area. \cr
- }}
-\subsection{Basic Tick Format}{
+ }
+}
+
+\section{Basic tick format parameters}{
+
 \tabular{ll}{
 \code{power_limit_high} \tab (int) Limit the use of scientific notation to when log(x) >= value. \cr
 \code{power_limit_low} \tab (int) Limit the use of scientific notation to when log(x) <= value. \cr
@@ -89,22 +91,31 @@ Add y axis to a Bokeh figure
  determined if not specified. \cr
 \code{use_scientific} \tab (logical) Whether to ever display scientific notation. If True, then when to use scientific
  notation is controlled by \code{power_limit_low} and \code{power_limit_high}. \cr
- }}
-\subsection{Datetime Tick Format}{
+ }
+}
+
+\section{Datetime tick format parameters}{
+
 \tabular{ll}{
 \code{formats} \tab (list) Display tick values from a continuous range as formatted datetimes.
  See \href{http://bokeh.pydata.org/en/latest/docs/reference/models.html\#bokeh.models.formatters.DatetimeTickFormatter}{DatetimeTickFormatter}. \cr
- }}
-\subsection{Numeral Tick Format}{
+ }
+}
+
+\section{Numeral tick format parameters}{
+
 \tabular{ll}{
 \code{format} \tab (string) Tick formatter based on a human-readable format string.
  See \href{http://bokeh.pydata.org/en/latest/docs/reference/models.html\#bokeh.models.formatters.NumeralTickFormatter}{NumeralTickFormatter}. \cr
- }}
-\subsection{Printf Tick Format}{
+ }
+}
+
+\section{Printf tick format parameters}{
+
 \tabular{ll}{
 \code{format} \tab (string) Tick formatter based on a printf-style format string.
  See \href{http://bokeh.pydata.org/en/latest/docs/reference/models.html\#bokeh.models.formatters.PrintfTickFormatter}{PrintfTickFormatter}. \cr
- }}
+ }
 }
 \examples{
 \donttest{


### PR DESCRIPTION
Improves the documentation for axis tick formatting.  It was not possible to use section titles that include a colon (e.g. "Additional parameters: Axis:"), as roxygen2 splits the section title at the first colon.